### PR TITLE
SPAをブラウザの前に戻る・次に進むボタンに対応

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,6 @@
       "source.organizeImports": "always"
     }
   },
-  "files.insertFinalNewline": true
+  "files.insertFinalNewline": true,
+  "makefile.configureOnOpen": false
 }

--- a/django/backend/pong/templates/pong/script.html
+++ b/django/backend/pong/templates/pong/script.html
@@ -48,6 +48,12 @@
   <p>ユーザーログアウト</p>
   {% endif %}
 
+  <button id="test-button" >save
+  </button>
+    <input type="text" id="test-input"/ >
+
   <div id="test_spa">test_spa_replace?</div>
+  <!--
   <script src="{% static 'pong/js/test.js' %}"></script>
+-->
 </body>

--- a/django/frontend/src/index.html
+++ b/django/frontend/src/index.html
@@ -18,7 +18,7 @@
     <a href="/settings" class="nav__link" data-link>Settings</a>
     <a href="/signup" class="nav__link" data-link>Sign_up</a>
     <a href="/login" class="nav__link" data-link>Log_in</a>
-    <a href="/lang" class="nav__link" data-link>Lang</a>
+    <a href="/lang" class="nav__link" data-link id="lang-page">Lang</a>
     <a href="/script" class="nav__link" data-link>Script</a>
     <a href="/scriptt" class="nav__link" data-link>Script2</a>
     <a href="/success-login" class="nav__link" data-link>Success-login</a>

--- a/django/frontend/src/index.js
+++ b/django/frontend/src/index.js
@@ -1,5 +1,6 @@
 import { Routes } from './spa/js/routing/routes.js';
-import { navigateTo, router, updatePage } from './spa/js/routing/routing.js';
+//import { navigateTo, router, updatePage } from './spa/js/routing/routing.js';
+import { navigateTo, updatePage } from './spa/js/routing/routing.js';
 import { changingLanguage } from './spa/js/utility/lang.js';
 import { getUrl } from './spa/js/utility/url.js';
 import { fetchAsForm } from './spa/js/utility/fetch.js';
@@ -7,8 +8,6 @@ import './accounts/js/two_fa.js';
 
 import './spa/scss/spa.scss';
 import './main.scss';
-
-window.addEventListener('popstate', router);
 
 // パス名を取得する関数
 const getDisplayedURI = (pathname) => {

--- a/django/frontend/src/pong/js/test.js
+++ b/django/frontend/src/pong/js/test.js
@@ -1,2 +1,12 @@
 console.log('test.js Replace Test ');
-document.getElementById('replace').textContent = 'AAAAAAAABBBBBBDDDDDFFFFFFF5';
+import { navigateTo } from '../../spa/js/routing/routing.js';
+
+export const ScriptEvent = new Event('ScriptEvent');
+
+document.addEventListener('ScriptEvent', function () {
+  const test_button = document.getElementById('test-button');
+  test_button.addEventListener('click', () => {
+    let tmp_path = window.location.pathname;
+    navigateTo(tmp_path);
+  });
+});

--- a/django/frontend/src/spa/js/routing/routing.js
+++ b/django/frontend/src/spa/js/routing/routing.js
@@ -2,15 +2,36 @@ import { Routes } from './routes.js';
 import { getUrl } from '../utility/url.js';
 import { isLogined } from '../utility/user.js';
 import { executeScriptTab } from '../utility/script.js';
-//import '../../../accounts/js/two_fa.js';
-//import { TwoFaEvent } from '../../../accounts/js/two_fa.js';
+
+let view = undefined;
+window.addEventListener('popstate', async (event) => {
+  try {
+    const stateJson = await event.state;
+    for (let key in stateJson) {
+      console.log(key + ': ' + stateJson[key]);
+      document.getElementById(key).value = stateJson[key];
+    }
+  } catch (error) {
+    console.error(error);
+  }
+});
 
 const pathToRegex = (path) =>
   new RegExp('^' + path.replace(/\//g, '\\/').replace(/:\w+/g, '(.+)') + '$');
 
-export const navigateTo = (url) => {
-  history.pushState(null, null, url);
-  router();
+export const navigateTo = async (url) => {
+  const setState = async () => {
+    if (view !== undefined) {
+      const state = await view.getState();
+      history.pushState(state, null, url);
+    } else {
+      history.pushState(null, null, url);
+    }
+    view = router();
+    return await view;
+  };
+  view = await setState();
+  return view;
 };
 
 export const router = async () => {
@@ -46,6 +67,7 @@ export const router = async () => {
   } catch (error) {
     console.error('executeScript Error:' + error);
   }
+  return view;
 };
 
 /*

--- a/django/frontend/src/spa/js/utility/lang.js
+++ b/django/frontend/src/spa/js/utility/lang.js
@@ -13,6 +13,8 @@ export async function changingLanguage(url, form, current_uri) {
     const result = await response.text();
     if (result) {
       navigateTo(current_uri);
+
+      // 画面更新したいだけ
       router();
     } else {
       console.error('Failure');

--- a/django/frontend/src/spa/js/views/AbstractView.js
+++ b/django/frontend/src/spa/js/views/AbstractView.js
@@ -7,10 +7,13 @@ export default class {
     document.title = title;
   }
 
-  async getHtml() {
-    return "";
-  }
-  async executeScript() {
-    return "";
-  }
+  getHtml = async () => {
+    return '';
+  };
+  executeScript = () => {
+    return '';
+  };
+  getState = () => {
+    return '';
+  };
 }

--- a/django/frontend/src/spa/js/views/Accounts.js
+++ b/django/frontend/src/spa/js/views/Accounts.js
@@ -1,20 +1,23 @@
-import AbstractView from "./AbstractView.js";
-import fetchData from "../utility/fetch.js";
-import { getUrlWithLang } from "../utility/url.js";
-import { executeScriptTab } from "../utility/script.js";
+import AbstractView from './AbstractView.js';
+import fetchData from '../utility/fetch.js';
+import { getUrlWithLang } from '../utility/url.js';
+//import { executeScriptTab } from '../utility/script.js';
 
 export default class extends AbstractView {
   constructor(params) {
     super(params);
-    this.setTitle("Accounts");
+    this.setTitle('Accounts');
   }
 
-  async getHtml() {
-    const uri = getUrlWithLang("accounts/");
+  getHtml = async () => {
+    const uri = getUrlWithLang('accounts/');
     const data = await fetchData(uri);
     return data;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     //executeScriptTab("");
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/Admin.js
+++ b/django/frontend/src/spa/js/views/Admin.js
@@ -1,20 +1,23 @@
-import AbstractView from "./AbstractView.js";
-import fetchData from "../utility/fetch.js";
-import { getUrlWithLang } from "../utility/url.js";
-import { executeScriptTab } from "../utility/script.js";
+import AbstractView from './AbstractView.js';
+import fetchData from '../utility/fetch.js';
+import { getUrlWithLang } from '../utility/url.js';
+//import { executeScriptTab } from '../utility/script.js';
 
 export default class extends AbstractView {
   constructor(params) {
     super(params);
-    this.setTitle("Admin");
+    this.setTitle('Admin');
   }
 
-  async getHtml() {
-    const uri = getUrlWithLang("/admin/login/?next=/");
+  getHtml = async () => {
+    const uri = getUrlWithLang('/admin/login/?next=/');
     const data = await fetchData(uri);
     return data;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     //executeScriptTab("");
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/Dashboard.js
+++ b/django/frontend/src/spa/js/views/Dashboard.js
@@ -1,13 +1,13 @@
-import AbstractView from "./AbstractView.js";
-import { executeScriptTab } from "../utility/script.js";
+import AbstractView from './AbstractView.js';
+//import { executeScriptTab } from '../utility/script.js';
 
 export default class extends AbstractView {
   constructor(params) {
     super(params);
-    this.setTitle("Dashboard");
+    this.setTitle('Dashboard');
   }
 
-  async getHtml() {
+  getHtml = async () => {
     return `
             <h1>Welcome back, Dom</h1>
             <p>
@@ -17,8 +17,11 @@ export default class extends AbstractView {
                 <a href="/posts" data-link>View recent posts</a>.
             </p>
         `;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     //executeScriptTab("");
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/Index.js
+++ b/django/frontend/src/spa/js/views/Index.js
@@ -1,20 +1,23 @@
-import AbstractView from "./AbstractView.js";
-import fetchData from "../utility/fetch.js";
-import { getUrlWithLang } from "../utility/url.js";
-import { executeScriptTab } from "../utility/script.js";
+import AbstractView from './AbstractView.js';
+import fetchData from '../utility/fetch.js';
+import { getUrlWithLang } from '../utility/url.js';
+//import { executeScriptTab } from '../utility/script.js';
 
 export default class extends AbstractView {
   constructor(params) {
     super(params);
-    this.setTitle("Home");
+    this.setTitle('Home');
   }
 
-  async getHtml() {
-    const uri = getUrlWithLang("/home");
+  getHtml = async () => {
+    const uri = getUrlWithLang('/home');
     const data = await fetchData(uri);
     return data;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     //executeScriptTab("");
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/Lang.js
+++ b/django/frontend/src/spa/js/views/Lang.js
@@ -1,7 +1,7 @@
 import AbstractView from './AbstractView.js';
 import fetchData from '../utility/fetch.js';
 import { getUrlWithLang } from '../utility/url.js';
-import { executeScriptTab } from '../utility/script.js';
+//import { executeScriptTab } from '../utility/script.js';
 
 export default class extends AbstractView {
   constructor(params) {
@@ -9,12 +9,15 @@ export default class extends AbstractView {
     this.setTitle('Lang');
   }
 
-  async getHtml() {
+  getHtml = async () => {
     const uri = getUrlWithLang('pong/lang');
     const data = await fetchData(uri);
     return data;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     //executeScriptTab("");
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/Login.js
+++ b/django/frontend/src/spa/js/views/Login.js
@@ -10,13 +10,16 @@ export default class extends AbstractView {
     this.setTitle('Log in');
   }
 
-  async getHtml() {
+  getHtml = async () => {
     console.log('Login Test');
     const uri = getUrlWithLang('accounts/login');
     const data = fetchData(uri);
     return data;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     document.dispatchEvent(LoginEvent);
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/LoginSuccess.js
+++ b/django/frontend/src/spa/js/views/LoginSuccess.js
@@ -8,12 +8,15 @@ export default class extends AbstractView {
     this.setTitle('Log in Success');
   }
 
-  async getHtml() {
+  getHtml = async () => {
     const uri = getUrlWithLang('accounts/success-login/');
     const data = fetchData(uri);
     return data;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     //executeScriptTab('');
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/LoginSuccess2.js
+++ b/django/frontend/src/spa/js/views/LoginSuccess2.js
@@ -7,14 +7,17 @@ export default class extends AbstractView {
     this.setTitle('Posts');
   }
 
-  async getHtml() {
+  getHtml = async () => {
     return `
             <h1>Posts2</h1>
             <p>You are viewing the posts!!!1234A</p>
             <a href="/settings" class="nav__link" data-link>Settings</a>
         `;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     executeScriptTab('');
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/Logout.js
+++ b/django/frontend/src/spa/js/views/Logout.js
@@ -1,7 +1,7 @@
 import AbstractView from './AbstractView.js';
 import fetchData from '../utility/fetch.js';
 import { getUrlWithLang } from '../utility/url.js';
-import { executeScriptTab } from '../utility/script.js';
+//import { executeScriptTab } from '../utility/script.js';
 
 export default class extends AbstractView {
   constructor(params) {
@@ -9,12 +9,15 @@ export default class extends AbstractView {
     this.setTitle('Log out');
   }
 
-  async getHtml() {
+  getHtml = async () => {
     const uri = getUrlWithLang('accounts/logout');
     const data = fetchData(uri);
     return data;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     //executeScriptTab("");
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/Pong.js
+++ b/django/frontend/src/spa/js/views/Pong.js
@@ -1,21 +1,24 @@
-import AbstractView from "./AbstractView.js";
-import fetchData from "../utility/fetch.js";
-import { getUrlWithLang } from "../utility/url.js";
-import { executeScriptTab } from "../utility/script.js";
+import AbstractView from './AbstractView.js';
+import fetchData from '../utility/fetch.js';
+import { getUrlWithLang } from '../utility/url.js';
+//import { executeScriptTab } from "../utility/script.js";
 
 export default class extends AbstractView {
   constructor(params) {
     super(params);
-    this.setTitle("Pong");
+    this.setTitle('Pong');
   }
 
-  async getHtml() {
-    const uri = getUrlWithLang("/pong/");
+  getHtml = async () => {
+    const uri = getUrlWithLang('/pong/');
     const data = await fetchData(uri);
     //console.log("Pong:" + data);
     return data;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     //executeScriptTab("");
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/PostView.js
+++ b/django/frontend/src/spa/js/views/PostView.js
@@ -1,20 +1,23 @@
-import AbstractView from "./AbstractView.js";
-import { executeScriptTab } from "../utility/script.js";
+import AbstractView from './AbstractView.js';
+//import { executeScriptTab } from '../utility/script.js';
 
 export default class extends AbstractView {
   constructor(params) {
     super(params);
     this.postId = params.id;
-    this.setTitle("Viewing Post");
+    this.setTitle('Viewing Post');
   }
 
-  async getHtml() {
+  getHtml = async () => {
     return `
             <h1>Post</h1>
             <p>You are viewing post #${this.postId}.</p>
         `;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     //executeScriptTab("");
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/Posts.js
+++ b/django/frontend/src/spa/js/views/Posts.js
@@ -7,14 +7,17 @@ export default class extends AbstractView {
     this.setTitle('Posts');
   }
 
-  async getHtml() {
+  getHtml = async () => {
     return `
             <h1>Posts</h1>
             <p>You are viewing the posts!!!1234A</p>
             <a href="/settings" class="nav__link" data-link>Settings</a>
         `;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     //executeScriptTab("");
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/Script.js
+++ b/django/frontend/src/spa/js/views/Script.js
@@ -1,23 +1,27 @@
-import AbstractView from "./AbstractView.js";
-import fetchData from "../utility/fetch.js";
-import { getUrlWithLang } from "../utility/url.js";
-import { executeScriptTab } from "../utility/script.js";
+import AbstractView from './AbstractView.js';
+import fetchData from '../utility/fetch.js';
+import { getUrlWithLang } from '../utility/url.js';
+import { executeScriptTab } from '../utility/script.js';
+import { ScriptEvent } from '../../../pong/js/test.js';
 
 export default class extends AbstractView {
   constructor(params) {
     super(params);
-    this.setTitle("Script");
+    this.setTitle('Script');
   }
 
-  async getHtml() {
-    console.log("script getHtml()");
-    const uri = getUrlWithLang("pong/script");
-    console.log("script:" + uri);
+  getHtml = async () => {
+    const uri = getUrlWithLang('pong/script');
     const data = await fetchData(uri);
-    console.log("data:" + data);
     return data;
-  }
-  async executeScript() {
-    executeScriptTab("/static/spa/js/script/pong/test.js");
-  }
+  };
+  executeScript = () => {
+    executeScriptTab('/static/spa/js/script/pong/test.js');
+    document.dispatchEvent(ScriptEvent);
+  };
+  getState = () => {
+    const test_input = document.getElementById('test-input').value;
+    const state = { 'test-input': test_input };
+    return state;
+  };
 }

--- a/django/frontend/src/spa/js/views/Script2.js
+++ b/django/frontend/src/spa/js/views/Script2.js
@@ -1,24 +1,27 @@
-import AbstractView from "./AbstractView.js";
-import fetchData from "../utility/fetch.js";
-import { getUrlWithLang } from "../utility/url.js";
-import { executeScriptTab } from "../utility/script.js";
+import AbstractView from './AbstractView.js';
+import fetchData from '../utility/fetch.js';
+import { getUrlWithLang } from '../utility/url.js';
+import { executeScriptTab } from '../utility/script.js';
 
 export default class extends AbstractView {
   constructor(params) {
     super(params);
-    this.setTitle("Script2");
+    this.setTitle('Script2');
   }
 
-  async getHtml() {
-    const uri = getUrlWithLang("pong/script2");
+  getHtml = async () => {
+    const uri = getUrlWithLang('pong/script2');
     const data = await fetchData(uri);
-    console.log("script2:" + uri);
-    console.log("data:" + data);
+    console.log('script2:' + uri);
+    console.log('data:' + data);
     return data;
-  }
+  };
 
-  async executeScript() {
+  executeScript = () => {
     //return '';
-    executeScriptTab("");
-  }
+    executeScriptTab('');
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/Settings.js
+++ b/django/frontend/src/spa/js/views/Settings.js
@@ -1,20 +1,23 @@
-import AbstractView from "./AbstractView.js";
-import { executeScriptTab } from "../utility/script.js";
+import AbstractView from './AbstractView.js';
+//import { executeScriptTab } from '../utility/script.js';
 
 export default class extends AbstractView {
   constructor(params) {
     super(params);
-    this.setTitle("Settings");
+    this.setTitle('Settings');
   }
 
-  async getHtml() {
+  getHtml = async () => {
     return `
             <h1>Settings</h1>
             <p>Manage your privacy and configuration.</p>
             <a href="/posts" class="nav__link" data-link>Posts</a>
         `;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     //executeScriptTab("");
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/Signup.js
+++ b/django/frontend/src/spa/js/views/Signup.js
@@ -10,12 +10,15 @@ export default class extends AbstractView {
     this.setTitle('Sign up');
   }
 
-  async getHtml() {
+  getHtml = async () => {
     const uri = getUrlWithLang('accounts/signup');
     const data = fetchData(uri);
     return data;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     document.dispatchEvent(SignupEvent);
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }

--- a/django/frontend/src/spa/js/views/TwoFA.js
+++ b/django/frontend/src/spa/js/views/TwoFA.js
@@ -9,13 +9,16 @@ export default class extends AbstractView {
     this.setTitle('Two-Factor Authentication');
   }
 
-  async getHtml() {
+  getHtml = async () => {
     console.log('2FA');
     const uri = getUrlWithLang('accounts/two-fa/');
     const data = fetchData(uri);
     return data;
-  }
-  async executeScript() {
+  };
+  executeScript = () => {
     document.dispatchEvent(TwoFaEvent);
-  }
+  };
+  getState = () => {
+    return null;
+  };
 }


### PR DESCRIPTION
従来のSPAでは、例えばボタンを押してページ内の一部分が変化し、そのあとにブラウザの戻るボタンを押しても、ボタンを押す前の状態に戻ることはなかったので、状態を保持し、前に戻る・次の進むボタンを押したらその状態に戻るような仕組みを作成した。

次のように対応すれば、ブラウザのボタンに対応してくれる
https://qiita.com/hsano43/private/f9ad16419c90ebb9d050#%E3%83%96%E3%83%A9%E3%82%A6%E3%82%B6%E3%81%AE%E5%89%8D%E3%81%AB%E6%88%BB%E3%82%8B%E6%AC%A1%E3%81%AB%E9%80%B2%E3%82%80%E3%83%9C%E3%82%BF%E3%83%B3%E3%81%AE%E5%AF%BE%E5%BF%9C