### PR TITLE
ブラウザの言語設定を変えると、正常に表示されないバグ修正

### DIFF
--- a/django/backend/ft_trans/settings_dev.py
+++ b/django/backend/ft_trans/settings_dev.py
@@ -118,6 +118,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.RemoteUserMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    # "LanguageFallbackMiddleware",
     "users.middleware.UserActionLoggingMiddleware",  # Log保管用
 ]
 

--- a/django/frontend/src/spa/js/utility/url.js
+++ b/django/frontend/src/spa/js/utility/url.js
@@ -14,8 +14,8 @@ export function getUrlWithLang(path) {
   const http = window.location.protocol;
   const domain = window.location.host;
   let lang = getUserLanguage();
-  if (!lang) {
-    lang = '';
+  if (!(lang == 'ja' || lang == 'en' || lang == 'fr')) {
+    lang = 'ja';
   }
   return http + '//' + domain + '/' + lang + '/' + path;
   //return http + '//' + domain + '/' + path;


### PR DESCRIPTION
#81 の不具合修正
対応言語は、ja, en, frのみ。それ意義はjaに自動的に切り替える