### PR TITLE
ユーザー設定に応じて、言語が反映されるように変更

### DIFF
--- a/django/backend/accounts/middleware.py
+++ b/django/backend/accounts/middleware.py
@@ -137,9 +137,7 @@ class CustomSessionMiddleware(SessionMiddleware):
                             "is_signup": is_provisional_signup,
                             "exp": exp,
                             "nbf": datetime.now(tz=timezone.utc)
-                            + timedelta(
-                                seconds=3
-                            ),  # この時間より前に処理されたらエラーにする
+                            + timedelta(seconds=3),  # この時間より前に処理されたらエラーにする
                             "iat": datetime.now(tz=timezone.utc),
                             # "jti":"token-id" #必要なら使う
                         },
@@ -157,4 +155,20 @@ class CustomSessionMiddleware(SessionMiddleware):
                         httponly=settings.SESSION_COOKIE_HTTPONLY or None,
                         samesite=settings.SESSION_COOKIE_SAMESITE,
                     )
+                    try:
+                        lang = request.user.language
+                        response.set_cookie(
+                            "django_language",
+                            lang,
+                            max_age=max_age,
+                            expires=expires,
+                            domain=settings.SESSION_COOKIE_DOMAIN,
+                            path=settings.SESSION_COOKIE_PATH,
+                            secure=None,
+                            httponly=None,
+                            samesite=settings.SESSION_COOKIE_SAMESITE,
+                        )
+
+                    except Exception:
+                        lang = ""
         return response

--- a/django/frontend/src/spa/js/utility/url.js
+++ b/django/frontend/src/spa/js/utility/url.js
@@ -1,8 +1,4 @@
-function getUserLanguage() {
-  return window.navigator.languages && window.navigator.languages[0]
-    ? window.navigator.language
-    : sessionStorage.getItem('userLanguage');
-}
+import Cookies from 'js-cookie';
 
 export function getUrl(path) {
   const http = window.location.protocol;
@@ -13,10 +9,9 @@ export function getUrl(path) {
 export function getUrlWithLang(path) {
   const http = window.location.protocol;
   const domain = window.location.host;
-  let lang = getUserLanguage();
+  let lang = Cookies.get('django_language');
   if (!(lang == 'ja' || lang == 'en' || lang == 'fr')) {
     lang = 'ja';
   }
   return http + '//' + domain + '/' + lang + '/' + path;
-  //return http + '//' + domain + '/' + path;
 }


### PR DESCRIPTION
#82 の修正

辞書データが入っていないので、基本的に日本語のままだが、http://localhost:8001/lang で言語設定が切り替わっているかどうか確認できる。