### PR TITLE
dev環境でredisが動いていないので修正.ついでにsignup時にFtTmpUser削除

### DIFF
--- a/django/backend/accounts/backend.py
+++ b/django/backend/accounts/backend.py
@@ -4,22 +4,16 @@ from .models import FtUser, FtTmpUser
 
 class FtUserBackend(ModelBackend):
     def authenticate(self, request, email=None, password=None):
-        print("FtUser authenticate No.1")
         if email is None or password is None:
             return
-        print("FtUser authenticate No.2")
         user = FtUser.objects.get(email=email)
         pwd_valid = user.check_password(password)
         if pwd_valid:
-            print("FtUser authenticate No.3")
             return user
-        print("FtUser authenticate No.4")
         return None
 
     def get_user(self, user_id):
-        print("FtUser get_user No.1")
         try:
-            print("FtUser get_user No.2")
             return FtUser.objects.get(pk=user_id)
         except FtUser.DoesNotExist:
             return None
@@ -27,21 +21,15 @@ class FtUserBackend(ModelBackend):
 
 class TmpUserBackend(ModelBackend):
     def authenticate(self, request, email=None, password=None):
-        print("FtTmpUser authenticate No.1")
         if email is None or password is None:
             return
-        print("FtTmpUser authenticate No.2")
         user = FtTmpUser.objects.get(email=email)
         pwd_valid = user.check_password(password)
-        print("FtTmpUser authenticate No.3")
         if pwd_valid:
-            print("FtTmpUser authenticate No.4")
             return user
-        print("FtTmpUser authenticate No.5")
         return None
 
     def get_user(self, user_id):
-        print("FtTmpUser  get_user No.1")
         try:
             return FtTmpUser.objects.get(pk=user_id)
         except FtTmpUser.DoesNotExist:

--- a/django/backend/accounts/tasks.py
+++ b/django/backend/accounts/tasks.py
@@ -11,7 +11,6 @@ def delete_tmp_user(user_id):
 
 @shared_task
 def change_login_state(user_id, flag):
-    print("change_login_state No.1")
     user = FtTmpUser.objects.get(id=user_id)
     if user is None:
         return

--- a/django/backend/accounts/views.py
+++ b/django/backend/accounts/views.py
@@ -113,6 +113,7 @@ def copy_tmpuser_to_ftuser(user):
             is_staff=src_user.is_staff,
             language=src_user.language,
         )
+        return src_user
     except IntegrityError as e:
         print(f"Copy Error:{e}")
     except Exception as e:
@@ -138,7 +139,7 @@ class SignupTwoFaView(CreateView):
 
             if rval is False:
                 return HttpResponseBadRequest("Failure to verify")
-            copy_tmpuser_to_ftuser(user)
+            tmp_user = copy_tmpuser_to_ftuser(user)
 
             new_user = FtUser.objects.get(email=user.email)
             login(
@@ -146,7 +147,7 @@ class SignupTwoFaView(CreateView):
                 new_user,
                 backend="django.contrib.auth.backends.ModelBackend",
             )
-
+            tmp_user.delete()
             tmp_time = datetime.now(tz=timezone.utc) + timedelta(
                 seconds=getattr(settings, "JWT_VALID_TIME", None)
             )

--- a/django/backend/ft_trans/redis.py
+++ b/django/backend/ft_trans/redis.py
@@ -6,11 +6,13 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ft_trans.settings")
 
 # app: Celery = Celery("ft_trans")
 password = getattr(settings, "REDIS_PASSWORD", None)
+ssl = getattr(settings, "REDIS_SSL", None)
+port = getattr(settings, "REDIS_PORT", None)
 app = redis.Redis(
     host="redis",
     port=6379,
     password=password,
-    ssl=True,
+    ssl=ssl,
     ssl_cert_reqs="none",
 )
 

--- a/django/backend/ft_trans/settings_dev.py
+++ b/django/backend/ft_trans/settings_dev.py
@@ -240,7 +240,7 @@ AUTHENTICATION_BACKENDS = [
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": f"rediss://default:{os.environ['REDIS_PASSOWRD']}@172.38.30.30:6379",
+        "LOCATION": f"redis://default:{os.environ['REDIS_PASSOWRD']}@172.38.30.30:6380",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "SSL_CERT_REQS": None,  # SSL証明書の検証をスキップ
@@ -248,7 +248,8 @@ CACHES = {
     }
 }
 REDIS_SERVER = "redis"
-REDIS_PORT = 6379
+REDIS_PORT = 6380
+REDIS_SSL = False
 REDIS_PASSWORD = os.environ["REDIS_PASSOWRD"]
 
 # Celery configurations
@@ -265,7 +266,7 @@ CELERY_CACHE_BACKEND = "django-cache"
 
 # Celery設定
 # CELERY_BROKER_URL = os.environ.get("REDIS_URL", "redis://redis:6379/1")
-CELERY_BROKER_URL = f"rediss://default:{os.environ['REDIS_PASSOWRD']}@172.38.30.30:6379"
+CELERY_BROKER_URL = f"redis://default:{os.environ['REDIS_PASSOWRD']}@172.38.30.30:6380"
 CELERY_RESULT_BACKEND = "django-db"
 
 CELERY_RESULT_EXTENDED = True

--- a/django/backend/ft_trans/settings_prod.py
+++ b/django/backend/ft_trans/settings_prod.py
@@ -243,6 +243,7 @@ CACHES = {
 }
 REDIS_SERVER = "redis"
 REDIS_PORT = 6379
+REDIS_SSL = True
 REDIS_PASSWORD = os.environ["REDIS_PASSOWRD"]
 
 # Celery configurations


### PR DESCRIPTION
#83 の修正

本番環境は動いていたが、開発環境ではredisが動いていなかった。
原因は、redissにしていたことと、portがtlsようになっていたので、本番環境と開発環境で切り分けることで対応した。
ただし、実際に課題として提出する際は、開発環境のportはセキュリティリスクになるので閉じる必要がある

また、これまではFtTmpUserが作られて5分後に削除するようにしていたが、サインアップ時の2FAが完了と同時に削除もするように変更した。
