### PR TITLE
signup時にキャンセルしても、同じメールアドレスで登録できるように修正

### DIFF
--- a/django/backend/accounts/templates/accounts/two-fa-modal.html
+++ b/django/backend/accounts/templates/accounts/two-fa-modal.html
@@ -68,10 +68,13 @@
               </button>
             </form>
           </div>
-          <div>
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-              {% trans "閉じる" %}
-            </button>
+          <div class="d-flex justify-content-between">
+            <form action="{% url 'accounts:cancel-two-fa' %}" method="post" id="cancel-two-fa">
+              <input type="text" id="cancel-two-fa-target" name="target" value="login" hidden />
+              <button type="submit" class="btn btn-secondary me-3" data-bs-dismiss="modal">
+                {% trans "キャンセル" %}
+              </button>
+            </form>
             <button
               type="submit"
               class="btn btn-primary"

--- a/django/backend/accounts/urls.py
+++ b/django/backend/accounts/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path("redirect-oauth", views.redirect_oauth, name="redirect-oauth"),
     path("oauth-login", views.oauth_login, name="oauth-login"),
     path("login-signup/", views.LoginSignupView.as_view(), name="login-signup"),
+    path("cancel-two-fa", views.CancelTwoFa.as_view(), name="cancel-two-fa"),
 ]

--- a/django/backend/accounts/views.py
+++ b/django/backend/accounts/views.py
@@ -196,6 +196,27 @@ def two_fa_verify(request):
 
 
 @method_decorator(login_not_required, name="dispatch")
+class CancelTwoFa(TemplateView):
+    def get():
+        return HttpResponseBadRequest("Bad Request")
+
+    def post(self, request):
+        target = request.POST.get("target")
+        if target == "signup":
+            is_provisional_signup = False
+            if "is_provisional_signup" in request.session:
+                is_provisional_signup = request.session["is_provisional_signup"]
+            if is_provisional_signup is False:
+                return HttpResponse()
+            id = request.session["user_id"]
+            user = FtTmpUser.objects.get(id=id)
+            if user is None:
+                return HttpResponse()
+            user.delete()
+        return HttpResponse()
+
+
+@method_decorator(login_not_required, name="dispatch")
 class LoginSignupView(TemplateView):
     ft_oauth = FtOAuth()
     url = ft_oauth.get_ft_authorization_url()

--- a/django/frontend/src/accounts/js/login.js
+++ b/django/frontend/src/accounts/js/login.js
@@ -52,8 +52,10 @@ document.addEventListener('LoginEvent', function () {
             const json = await response.json();
             const two_fa_form = document.getElementById('two-fa-verify-form');
             const resend_two_fa_form = document.getElementById('resend-two-fa');
+            const cancel_two_fa_target = document.getElementById('cancel-two-fa-target');
             two_fa_form.action = getUrlWithLang('accounts/login-two-fa/');
             resend_two_fa_form.action = 'accounts/login-two-fa/';
+            cancel_two_fa_target.value = 'login';
             document.getElementById('app_url_qr').hidden = true;
             if (json['is_auth_app']) {
               document.getElementById('resend-button').hidden = true;

--- a/django/frontend/src/accounts/js/signup.js
+++ b/django/frontend/src/accounts/js/signup.js
@@ -50,8 +50,11 @@ document.addEventListener('SignupEvent', function () {
           }
           const two_fa_form = document.getElementById('two-fa-verify-form');
           const resend_two_fa_form = document.getElementById('resend-two-fa');
+          const cancel_two_fa_target = document.getElementById('cancel-two-fa-target');
+
           two_fa_form.action = getUrlWithLang('accounts/signup-two-fa/');
           resend_two_fa_form.action = 'accounts/signup-two-fa/';
+          cancel_two_fa_target.value = 'signup';
           if (json['is_auth_app']) {
             document.getElementById('app_url_qr').hidden = false;
             document.getElementById('app_url_qr').src = 'data:image/png;base64,' + json['qr'];

--- a/django/frontend/src/accounts/js/two_fa.js
+++ b/django/frontend/src/accounts/js/two_fa.js
@@ -30,6 +30,7 @@ document.addEventListener('TwoFaEvent', function () {
   const error_message = document.getElementById('failure-verify');
   const resend_error = document.getElementById('failure-resend');
   const resend_two_fa = document.getElementById('resend-two-fa');
+  const cancel_two_fa = document.getElementById('cancel-two-fa');
 
   two_fa_form.addEventListener('submit', async function (event) {
     const response = await submitForm(event);
@@ -48,6 +49,15 @@ document.addEventListener('TwoFaEvent', function () {
     await moveTo('games');
     WebsocketInit();
   });
+
+  cancel_two_fa.addEventListener('submit', async (event) => {
+    const response = await submitForm(event);
+    if (response.status != 200) {
+      console.error('Error:cancel TwoFa');
+      return;
+    }
+  });
+
   input_code.addEventListener('input', () => {
     error_message.hidden = true;
     resend_error.hidden = true;


### PR DESCRIPTION
#79 対応

singup時、2FAの行う前の段階で仮ユーザーを登録している。
そのため、2FAをキャンセルすると、仮ユーザーだけが登録されたままになるので、同じemailは登録できなくなる（ただし、仮ユーザーは5分後に自動で削除されるため、5分経てば同じemailでも登録可能)。
今回、キャンセルボタンを押したタイミングで仮ユーザーを削除することで、キャンセル後即座に同じemailでも登録できるようにした