### PR TITLE
フレンドリクエストを送信した相手に、フレンドリクエスト送信できなくした

### DIFF
--- a/django/backend/accounts/oauth.py
+++ b/django/backend/accounts/oauth.py
@@ -57,11 +57,9 @@ class FtOAuth(ModelBackend):
     REDIRECTED_URL = DOMAIN + "accounts/redirect-oauth"
 
     def authenticate(self, username, email):
-        print("ftOauth authenticate No.1")
         try:
             user = FtUser.objects.get(email42=email)
         except FtUser.DoesNotExist:
-            print("ftOauth authenticate No.2")
             user = FtUser()
             cnt = 0
             try:

--- a/django/backend/friend/models.py
+++ b/django/backend/friend/models.py
@@ -9,7 +9,7 @@ class FriendshipsStatusChoices(models.TextChoices):
     ACCEPTED = "ACCEPTED", _("accepted")
     BLOCK = "BLOCK", _("block")  # ブロックする時
     BLOCKED = "BLOCKED", _("blocked")  # ブロックされた時
-    REMOVED = "REMOVED", _("removed")
+    # REMOVED = "REMOVED", _("removed") # 削除で対応する
 
 
 class Friendships(models.Model):

--- a/django/backend/friend/templates/friend/request-card.html
+++ b/django/backend/friend/templates/friend/request-card.html
@@ -26,7 +26,7 @@
           data-bs-toggle="modal"
           data-bs-target="#blockModal"
           data-name="{{request.user.username}}"
-          data-id="{{request.user.id}}"
+          data-id="{{request.id}}"
           data-img="{{request.user.avatar.url}}"
         >
           {% trans 'ブロック' %}
@@ -46,7 +46,7 @@
             value="{{request.id}}"
             name="{{request.user.username}}"
             data-name="{{request.user.username}}"
-            data-id="{{request.user.id}}"
+            data-id="{{request.id}}"
             data-img="{{request.user.avatar.url}}"
           >
             {% trans '許可' %}

--- a/django/backend/friend/templates/friend/request-card.html
+++ b/django/backend/friend/templates/friend/request-card.html
@@ -26,7 +26,7 @@
           data-bs-toggle="modal"
           data-bs-target="#blockModal"
           data-name="{{request.user.username}}"
-          data-id="{{request.id}}"
+          data-id="{{request.user.id}}"
           data-img="{{request.user.avatar.url}}"
         >
           {% trans 'ブロック' %}
@@ -46,7 +46,7 @@
             value="{{request.id}}"
             name="{{request.user.username}}"
             data-name="{{request.user.username}}"
-            data-id="{{request.id}}"
+            data-id="{{request.user.id}}"
             data-img="{{request.user.avatar.url}}"
           >
             {% trans '許可' %}

--- a/django/backend/friend/templates/friend/request-modal.html
+++ b/django/backend/friend/templates/friend/request-modal.html
@@ -37,7 +37,7 @@
         >
           {% csrf_token %}
 
-          <input id="modal-username" name="username" type="text" value="username" hidden />
+          <input id="modal-userid" name="userid" type="text" value="userid" hidden />
           <div class="mb-3 text-dark">
             <label for="exampleFormControlTextarea1" class="form-label"
               >{% trans "メッセージ" %}</label

--- a/django/backend/friend/templates/friend/request-modal.html
+++ b/django/backend/friend/templates/friend/request-modal.html
@@ -38,6 +38,15 @@
           {% csrf_token %}
 
           <input id="modal-userid" name="userid" type="text" value="userid" hidden />
+
+          <div id="friend-request-send-error" class="mb-1 text-danger" hidden>
+            {% trans "エラーが発生しました" %}
+            <br />
+            {% trans "相手がすでに登録したかもしれません" %}
+            <br />
+            {% trans "フレンドリクエストを確認してください" %}
+          </div>
+
           <div class="mb-3 text-dark">
             <label for="exampleFormControlTextarea1" class="form-label"
               >{% trans "メッセージ" %}</label

--- a/django/backend/friend/templates/friend/search.html
+++ b/django/backend/friend/templates/friend/search.html
@@ -84,6 +84,7 @@
                   class="request-button-name"
                   hidden
                   data-url="{{ friend.avatar.url }}"
+                  data-id="{{ friend.id}}"
                   data-name="{{ friend.username }}"
                 ></div>
                 <div hidden></div>

--- a/django/backend/friend/views.py
+++ b/django/backend/friend/views.py
@@ -78,12 +78,9 @@ class FindFriendView(ListView):
     paginate_by = 2
 
     def get_queryset(self):
-        print("test getqueryset No.1")
         friendships = Friendships.objects.filter(
             Q(user=self.request.user) | Q(friend=self.request.user)
         )
-        for friend_test in friendships:
-            print(f"{friend_test=}")
         # frendshipd_id = [friendship.friend.id for friendship in friendships]
         # フレンド関係にある人はすべて表示させない
         friend_id = [friendship.friend.id for friendship in friendships]
@@ -123,7 +120,6 @@ class RespondFriendRequest(UpdateView):
         friendship.save()
 
         if status == FriendshipsStatusChoices.BLOCKED:
-            print("Friend Status No.1")
             status = FriendshipsStatusChoices.BLOCK
 
         Friendships.objects.create(
@@ -160,12 +156,14 @@ class FriendRequest(CreateView):
     def post(self, request):
         try:
             user_id = request.POST.get("userid")
+            friend_user = FtUser.objects.get(id=user_id)
             message = request.POST.get("request-message")
 
-            friendship = Friendships.objects.get(
-                Q(user=user_id) & Q(friend=request.user)
+            # 相手側からすでにフレンド登録されていたらエラーとする
+            friendship = Friendships.objects.filter(
+                Q(user=friend_user) & Q(friend=request.user)
             )
-            if friendship is not None:
+            if len(friendship) > 0:
                 return HttpResponseBadRequest()
 
             tmp_friend = FtUser.objects.get(id=user_id)

--- a/django/frontend/src/friend/js/friend.js
+++ b/django/frontend/src/friend/js/friend.js
@@ -198,9 +198,13 @@ document.addEventListener('FriendEvent', () => {
     if (requests_form == null) {
       return;
     }
+    const error_message = document.getElementById('friend-request-send-error');
+
     requests_form.addEventListener('submit', async (event) => {
+      error_message.hidden = true;
       const response = await submitForm(event);
       if (response.status != 200) {
+        error_message.hidden = false;
         console.error('Error');
         return;
       }

--- a/django/frontend/src/friend/js/friend.js
+++ b/django/frontend/src/friend/js/friend.js
@@ -160,10 +160,13 @@ const friend_request_click = () => {
       }
 
       //const username = name_elements[0].textContent;
+      const user_id = name_elements[0].getAttribute('data-id');
       const username = name_elements[0].getAttribute('data-name');
       const img_url = name_elements[0].getAttribute('data-url');
-      document.getElementById('modal-username').value = username;
+      //document.getElementById('modal-username').value = username;
+      document.getElementById('modal-userid').value = user_id;
       document.getElementById('friend-user-name-head').textContent = username;
+      //document.getElementById('friend-user-id-head').textContent = user_id;
       document.getElementById('friend-user-icon-head').src = img_url;
     });
   });


### PR DESCRIPTION
#67 の対応

- [x] フレンド申請した相手は、検索にヒットしないように変更
- [x] 検索でヒットしたタイミングで相手からフレンド申請が来る可能性もあるので、フレンド申請したタイミングで、相手からフレンド申請が来ているかどうかをチェックしてエラーになるように変更した