### PR TITLE
トーナメント、フレンドページのデザインを微調整

### DIFF
--- a/django/backend/friend/templates/friend/answer-request-modal.html
+++ b/django/backend/friend/templates/friend/answer-request-modal.html
@@ -27,7 +27,7 @@
             </div>
             <div id="request-block-user-name" class="d-flex justify-content-center">username</div>
           </div>
-          <div class="mt-3">{% trans 'このユーザーをブロックします' %}</div>
+          <div class="mt-3 text-center">{% trans 'このユーザーをブロックします' %}</div>
           <div id="request-block-error" class="mt-3 text-wrap text-danger">
             {% trans 'エラーが発生しました。'%}
             <br />
@@ -88,7 +88,7 @@
             </div>
             <div id="request-accept-user-name" class="d-flex justify-content-center">username</div>
           </div>
-          <div class="mt-3">{% trans 'このユーザーをフレンドに追加します' %}</div>
+          <div class="mt-3 text-center">{% trans 'このユーザーをフレンドに追加します' %}</div>
           <div id="request-accept-error" class="mt-3 text-wrap text-danger">
             {% trans 'エラーが発生しました。'%}
             <br />

--- a/django/backend/friend/templates/friend/block-users-list.html
+++ b/django/backend/friend/templates/friend/block-users-list.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 <body>
-  <h2 class="d-flex justify-content-center justify-content-sm-start ms-0 ms-sm-5 mb-5">
-    {% trans 'ブロックユーザー'%}
-  </h2>
+  <div class="d-flex justify-content-center justify-content-sm-start ms-0 ms-sm-0 mb-5">
+    <h1>{% trans 'ブロックリスト'%}</h1>
+  </div>
   <ul class="pagination justify-content-center">
     {% if page_obj.has_previous %}
     <li class="page-item">

--- a/django/backend/friend/templates/friend/block-users.html
+++ b/django/backend/friend/templates/friend/block-users.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <br />
-    <div class="d-flex align-items-end">
+    <div class="d-flex align-items-center align-items-sm-end flex-column flex-sm-row">
       <h3>{% trans "ブロックリスト" %}</h3>
       <span class="h6 ps-2">
         {% if blocks %}

--- a/django/backend/friend/templates/friend/friend-list.html
+++ b/django/backend/friend/templates/friend/friend-list.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 <body>
-  <h2 class="d-flex justify-content-center justify-content-sm-start ms-0 ms-sm-5 mb-5">
-    {% trans 'フレンド'%}
-  </h2>
+  <div class="d-flex justify-content-center justify-content-sm-start ms-0 ms-sm-0 mb-5">
+    <h1>{% trans 'フレンドリスト'%}</h1>
+  </div>
   <ul class="pagination justify-content-center">
     {% if page_obj.has_previous %}
     <li class="page-item">

--- a/django/backend/friend/templates/friend/friend.html
+++ b/django/backend/friend/templates/friend/friend.html
@@ -7,6 +7,7 @@
     <title>Make Friend</title>
   </head>
   <body>
+    <h1 class="mb-5">{% trans "Friend" %}</h1>
     {% include 'friend/search-form.html' %}
 
     <div id="friend-request" class="mt-5">

--- a/django/backend/friend/templates/friend/friends.html
+++ b/django/backend/friend/templates/friend/friends.html
@@ -50,7 +50,7 @@
 -->
 
     <br />
-    <div class="d-flex align-items-end">
+    <div class="d-flex align-items-center align-items-sm-end flex-column flex-sm-row">
       <h3>{% trans "フレンドリスト" %}</h3>
       <span class="h6 ps-2">
         {% if friends %}

--- a/django/backend/friend/templates/friend/request-list.html
+++ b/django/backend/friend/templates/friend/request-list.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 <body>
-  <h2 class="d-flex justify-content-center justify-content-sm-start ms-0 ms-sm-5 mb-5">
-    {% trans 'フレンドリクエスト'%}
-  </h2>
+  <div class="d-flex justify-content-center justify-content-sm-start ms-0 ms-sm-0 mb-5">
+    <h1>{% trans 'フレンドリクエスト'%}</h1>
+  </div>
   <ul class="pagination justify-content-center">
     {% if page_obj.has_previous %}
     <li class="page-item">

--- a/django/backend/friend/templates/friend/request.html
+++ b/django/backend/friend/templates/friend/request.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <br />
-    <div class="d-flex align-items-end">
+    <div class="d-flex align-items-center align-items-sm-end flex-column flex-sm-row">
       <h3>{% trans "フレンドリクエスト" %}</h3>
       {% if friend_requests%}
       <span class="h6 ps-2">

--- a/django/backend/tournament/templates/tournament/list.html
+++ b/django/backend/tournament/templates/tournament/list.html
@@ -7,9 +7,9 @@
     <title>Tournament List</title>
   </head>
   <body>
-    <h2 class="d-flex justify-content-center justify-content-sm-start ms-0 ms-sm-5 mb-5">
-      {{attr.title}}
-    </h2>
+    <div class="d-flex justify-content-center justify-content-sm-start ms-0 ms-sm-5 mb-5">
+      <h1>{{attr.title}}</h1>
+    </div>
     <!-- ページネーションのリンクを表示 -->
     <ul class="pagination justify-content-center">
       {% if page_obj.has_previous %}

--- a/django/backend/tournament/views.py
+++ b/django/backend/tournament/views.py
@@ -60,7 +60,10 @@ class OrganizedView(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["title"] = _("主催したトーナメント")
+        context["attr"] = {
+            "title": _("主催したトーナメント"),
+        }
+        # context["title"] = _("主催したトーナメント")
         return context
 
 
@@ -84,7 +87,10 @@ class ParticipantView(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["title"] = _("登録済みトーナメント")
+        context["attr"] = {
+            "title": _("登録済みトーナメント"),
+        }
+        # context["title"] = _("登録済みトーナメント")
         return context
 
 
@@ -99,7 +105,10 @@ class AllView(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["title"] = _("すべてのトーナメント")
+        context["attr"] = {
+            "title": _("すべてのトーナメント"),
+        }
+        # context["title"] = _("すべてのトーナメント")
         return context
 
 
@@ -225,7 +234,7 @@ class TournamentView(LoginRequiredMixin, CreateView):
             "display_register": False,
         }
         context["participant_status"] = {
-            "title": _("参加予定のトーナメント"),
+            "title": _("登録済みトーナメント"),
             "link": "/tournament/participant/",
             "button": _("詳細"),
             "display_register": False,

--- a/django/frontend/src/friend/scss/friend.scss
+++ b/django/frontend/src/friend/scss/friend.scss
@@ -8,8 +8,8 @@
 }
 
 .friend-card {
-  max-width: 16rem;
-  min-width: 16rem;
+  max-width: 14rem;
+  min-width: 14rem;
 }
 
 .card-img-top-block {

--- a/django/frontend/src/tournament/scss/tournament.scss
+++ b/django/frontend/src/tournament/scss/tournament.scss
@@ -77,13 +77,13 @@
 }
 
 .card-div {
-  max-width: 16rem;
-  min-width: 16rem;
+  max-width: 14rem;
+  min-width: 14rem;
   //background-color: aqua;
   //margin: 0 auto;
   .card-header {
-    max-width: 16rem;
-    min-width: 16rem;
+    max-width: 14rem;
+    min-width: 14rem;
     height: 4rem;
   }
 }


### PR DESCRIPTION
トーナメント、フレンドページに対して以下を実施した

- [x] レスポンシブ微調整
- [x] タイトル抜けの項目を修正
- [x] h1タグ付与
- [x] その他違和感のある配置を修正