### PR TITLE
 42OAuthでのloginで、42からの写真をavatar画像として登録する

### DIFF
--- a/django/backend/accounts/oauth.py
+++ b/django/backend/accounts/oauth.py
@@ -1,6 +1,7 @@
 from ft_trans import redis
 
 from django.conf import settings
+from django.core.files.base import ContentFile
 import urllib.parse
 import random
 import string
@@ -56,7 +57,7 @@ class FtOAuth(ModelBackend):
     DOMAIN = getattr(settings, "PONG_DOMAIN", None)
     REDIRECTED_URL = DOMAIN + "accounts/redirect-oauth"
 
-    def authenticate(self, username, email):
+    def authenticate(self, username, email, image_url):
         try:
             user = FtUser.objects.get(email42=email)
         except FtUser.DoesNotExist:
@@ -74,6 +75,13 @@ class FtOAuth(ModelBackend):
             user.created_at = datetime.datetime.now()
             user.save()
             user = FtUser.objects.get(email42=email)
+
+            response_img = requests.get(image_url)
+            if response_img.status_code == 200:
+                test_path = f'image_{image_url.split("/")[-1]}'
+                user.avatar.save(test_path, ContentFile(response_img.content))
+                user.save()
+
         return user
 
     def append_state_code_dict(self, state, code):
@@ -163,3 +171,6 @@ class FtOAuth(ModelBackend):
             logger.error("not find state in Redis")
             raise ValueError("Requestされたデータは無効です")
         return self.fetch_access_token(state, code)
+
+    def save_avatar(self, user, url):
+        pass

--- a/django/backend/accounts/views.py
+++ b/django/backend/accounts/views.py
@@ -420,7 +420,10 @@ def oauth_login(request):
         user_response = ft_oauth.fetch_user(access_token)
         username = user_response["login"]
         email = user_response["email"]
-        user = ft_oauth.authenticate(username=username, email=email)
+        image_url = user_response["image"]["link"]
+        user = ft_oauth.authenticate(
+            username=username, email=email, image_url=image_url
+        )
 
         if user is None:
             logger.error("failure to authenticate")


### PR DESCRIPTION
タイトル通り
#77 対応

ユーザーを作成じのみ42の画像を適用する。
もし、アバター画像を変更した場合、それ以降はloginしても変更はされない。
42の画像に戻したい場合は、ユーザーを削除した後に、再度42OAuthでloginすれば反映される