### PR TITLE
2fa用の秘密鍵をDB保存時に暗号化

### DIFF
--- a/django/backend/ft_trans/settings_dev.py
+++ b/django/backend/ft_trans/settings_dev.py
@@ -365,6 +365,9 @@ OAUTH_AUTHORIZE_URL = "https://api.intra.42.fr/oauth/authorize"
 OAUTH_CLIENT_ID = os.environ["OAUTH_CLIENT_ID"]
 OAUTH_SECRET_ID = os.environ["OAUTH_SECRET_ID"]
 
+# 2FA
+TWO_FA_AUTH_KEY = os.environ["TWO_FA_AUTH_KEY"]
+
 # ドメイン
 PONG_DOMAIN = "http://localhost:8001/"
 

--- a/django/backend/ft_trans/settings_prod.py
+++ b/django/backend/ft_trans/settings_prod.py
@@ -345,6 +345,9 @@ OAUTH_AUTHORIZE_URL = "https://api.intra.42.fr/oauth/authorize"
 OAUTH_CLIENT_ID = os.environ["OAUTH_CLIENT_ID"]
 OAUTH_SECRET_ID = os.environ["OAUTH_SECRET_ID"]
 
+# 2FA
+TWO_FA_AUTH_KEY = os.environ["TWO_FA_AUTH_KEY"]
+
 # ドメイン
 PONG_DOMAIN = "https://localhost/"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
       - BREVO_API_KEY=$BREVO_API_KEY
       - BREVO_SENDER_ADDRESS=$BREVO_SENDER_ADDRESS
       - REDIS_PASSOWRD=$REDIS_PASSOWRD
+      - TWO_FA_AUTH_KEY=$TWO_FA_AUTH_KEY
 
   eth:
     container_name: 'eth'

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -42,7 +42,8 @@ django-celery-results \
 redis \
 channels \
 pillow \
-python-magic
+python-magic \
+cryptography
 
 #django-redis #djang-redis is old
 #django-twilio


### PR DESCRIPTION
タイトル通り
#53 対応

DBをいじり、ライブラリも追加したので、これを導入以後は、make updateとDBの削除が必須