### PR TITLE
マイグレーションがうまくいかない不具合修正

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,12 @@ services:
       cp /tmp/make_db_setting.sh ./backend/make_db_setting.sh &&
       sh ./backend/make_db_setting.sh &&
       cd backend &&
+      python manage.py makemigrations accounts &&
+      python manage.py makemigrations tournament &&
+      python manage.py makemigrations friend &&
+      python manage.py makemigrations pong &&
+      python manage.py makemigrations users &&
+      python manage.py makemigrations notification &&
       python manage.py makemigrations &&
       python manage.py migrate &&
       (python manage.py loaddata ./**/fixtures/initial_data_prod.json || echo '') &&

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,12 @@ services:
       cp /tmp/make_db_setting.sh ./backend/make_db_setting.sh &&
       sh ./backend/make_db_setting.sh &&
       cd backend &&
+      python manage.py makemigrations accounts &&
+      python manage.py makemigrations tournament &&
+      python manage.py makemigrations friend &&
+      python manage.py makemigrations pong &&
+      python manage.py makemigrations users &&
+      python manage.py makemigrations notification &&
       python manage.py makemigrations &&
       python manage.py migrate &&
       (python manage.py loaddata ./**/fixtures/initial_data_prod.json || echo '') &&


### PR DESCRIPTION
新規にgit cloneしてmakeするとエラーになる。
原因は一部のマイグレーションが失敗するため。
おそらく、それぞれのアプリケーション毎に依存関係があるため、makemigrationsではその依存関係を考慮せずに実行しているので、エラーが発生して実行されないアプリケーションがあると思われる

個別にすべて書き出すことで対応した